### PR TITLE
Dandclark/2025 process share championed proposals

### DIFF
--- a/2025/selection-process.md
+++ b/2025/selection-process.md
@@ -44,7 +44,9 @@ remain participant confidential throughout the process. Final decisions
 will be published as the Interop team.
 
 Participating organizations are free to publish the list of proposals
-that they choose to champion and their reasoning for choosing them.
+that they were selected to champion and their reasoning for wanting
+to champion those proposals.
+
 Confidentiality also does not prevent participating organizations from
 sharing their own priorities or roadmaps outside of the Interop program.
 


### PR DESCRIPTION
Allow organizations to share publicly the list of proposals that they are championing. This was discussed in the [July 11 meeting](https://github.com/web-platform-tests/interop/issues/674) but did not reach consensus.

Change the wording to clarify that what is shared is the actual list of proposals the org is selected as champion for, not the list of proposals they were initially interested in championing.