### PR TITLE
Mappings for Interop 2026 focus areas to web-features

### DIFF
--- a/web-features.json
+++ b/web-features.json
@@ -344,7 +344,10 @@
       "scroll-snap"
    ],
     "interop-2026-shape": [
-      "shape-function"
+      "shape-function",
+      "shapes",
+      "path-shape",
+      "rect-xywx"
     ],
     "interop-2026-view-transitions": [
       "view-transitions",

--- a/web-features.json
+++ b/web-features.json
@@ -318,21 +318,21 @@
       "popover-hint"
     ],
     "interop-2026-fetch": [
-      "fetch-request-streams"
-      // Missing other parts
+      "fetch-request-streams",
+      "fetch-formdata"
     ],
     "interop-2026-indexeddb": [
       "getallrecords"
     ],
     "interop-2026-jspi-for-wasm": [
-      "wasm-jspi" // Wait for this PR: https://github.com/web-platform-dx/web-features/pull/3791
+      "wasm-jspi"
     ],
     "interop-2026-media-pseudo-classes": [
       "media-pseudos"
     ],
     "interop-2026-navigation": [
       "navigation",
-      "navigation-precommit-handlers" // Wait for this PR: https://github.com/web-platform-dx/web-features/pull/3792
+      "navigation-precommit-handlers"
     ],
     "interop-2026-scoped-custom-element-registries": [
       "scoped-custom-element-registries"
@@ -355,7 +355,6 @@
     ],
     "interop-2026-webcompat": [
       "top-level-await",
-      // missing timing of scroll event relative to animation event
       "user-select"
     ],
     "interop-2026-webrtc": [

--- a/web-features.json
+++ b/web-features.json
@@ -295,5 +295,78 @@
     "interop-2025-writingmodes": [
       "writing-mode"
     ]
+  },
+  "2026": {
+    "interop-2025-anchor-positioning": [
+      "anchor-positioning"
+    ],
+    "interop-2026-attr": [
+      "attr"
+    ],
+    "interop-2026-container-style-queries": [
+      "container-style-queries"
+    ],
+    "interop-2026-contrast-color": [
+      "contrast-color"
+    ],
+    "interop-2026-custom-highlights": [
+      "highlight"
+    ],
+    "interop-2026-dialogs-and-popovers": [
+      "dialog-closedby",
+      "open-pseudo",
+      "popover-hint"
+    ],
+    "interop-2026-fetch": [
+      "fetch-request-streams"
+      // Missing other parts
+    ],
+    "interop-2026-indexeddb": [
+      "getallrecords"
+    ],
+    "interop-2026-jspi-for-wasm": [
+      "wasm-jspi" // Wait for this PR: https://github.com/web-platform-dx/web-features/pull/3791
+    ],
+    "interop-2026-media-pseudo-classes": [
+      "media-pseudos"
+    ],
+    "interop-2026-navigation": [
+      "navigation",
+      "navigation-precommit-handlers" // Wait for this PR: https://github.com/web-platform-dx/web-features/pull/3792
+    ],
+    "interop-2026-scoped-custom-element-registries": [
+      "scoped-custom-element-registries"
+    ],
+    "interop-2026-scroll-driven-animations": [
+      "scroll-driven-animations"
+    ],
+    "interop-2026-scroll-snap": [
+      "scroll-snap"
+   ],
+    "interop-2026-shape": [
+      "shape-function"
+    ],
+    "interop-2026-view-transitions": [
+      "view-transitions",
+      "blocking-render",
+      "link-rel-expect",
+      "active-view-transition",
+      "cross-document-view-transitions"
+    ],
+    "interop-2026-webcompat": [
+      "top-level-await",
+      // missing timing of scroll event relative to animation event
+      "user-select"
+    ],
+    "interop-2026-webrtc": [
+      "webrtc",
+      "webrtc-encoded-transform"
+    ],
+    "interop-2026-webtransport": [
+      "webtransport"
+    ],
+    "interop-2026-zoom": [
+      "zoom"
+    ]
   }
 }


### PR DESCRIPTION
This adds the mappings between the Interop 20206 focus areas and web-features.

New web-features that were introduced to better match Interop focus areas:

* `wasm-jspi`, via https://github.com/web-platform-dx/web-features/pull/3791
* `navigation-precommit-handlers`, via https://github.com/web-platform-dx/web-features/pull/3792
* `fetch-formdata`, via https://github.com/web-platform-dx/web-features/pull/3813

Decisions for what _not_ to map:

* The remaining parts of the Fetch focus area are mime-type support and Range header support. Both of these are tracked in BCD in parts that aren't necessarily related to the Fetch API. So we can't really establish a useful mapping here.
* Timing of scroll events relative to animation events is not represented as a web-feature, and is more of a bug anyway.